### PR TITLE
チャンネル変更時の動作修正など

### DIFF
--- a/src/TVTest.cpp
+++ b/src/TVTest.cpp
@@ -8634,6 +8634,18 @@ void CMainWindow::OnCommand(HWND hwnd,int id,HWND hwndCtl,UINT codeNotify)
 						}
 					}
 
+					const CChannelInfo *pCurrentChInfo=ChannelManager.GetCurrentRealChannelInfo();
+					if (pCurrentChInfo!=NULL && pCurrentChInfo->GetChannelNo()==No+1) {
+						//チャンネルリストの現在位置より後ろのチャンネルを検索して、同一チャンネルNoのチャンネルがあれば取得
+						for (int i=ChannelManager.GetCurrentChannel()+1;i<pList->NumChannels();i++) {
+							const CChannelInfo *pChInfo=pList->GetChannelInfo(i);
+							if (pChInfo->IsEnabled() && pChInfo->GetChannelNo()==No+1) {
+								Index=i;
+								break;
+							}
+						}
+					}
+
 					if (Index<0) {
 						Logger.AddLog(TEXT("有効なチャンネルが見つかりません。チャンネルの設定を確認して下さい。"));
 						MainWindow.ShowMessage(TEXT("有効なチャンネルが見つかりません。\n設定のチャンネルスキャンでチャンネルのチェックボックスの状態とリモコンキー番号を確認して下さい。"),


### PR DESCRIPTION
チャンネル変更時に無効に設定したチャンネルが選択されてしまうのが気になったのでいくつか修正してみました。
お手数ですがご確認頂けますと幸いです。

・EPG番組表からのチャンネル変更時にenabledでないチャンネルが選択されてしまうのを修正
ifの条件にIsEnabled()を追加しただけです。

・パネルウィンドウの操作パネル等からのチャンネル変更時にenabledでないチャンネルが選択されてしまうのを修正
CChannelList::FindChannelNo()を修正しようかと思いましたが、複数箇所から参照されているのでやめました。

・パネルウィンドウの操作パネル等からのチャンネル変更時に現在のチャンネルNo(リモコンキー番号)と同じチャンネルNoが割り当てられているチャンネルがある場合はそのチャンネルに変更するようにした
複数のチャンネルに同一のチャンネルNoが割り当てられるのに、それを順番に切り替えられないのが気になったので切り替えられるようにしました。
