### PR TITLE
記述があいまいな部分などを修正

### DIFF
--- a/src/CaptureOptions.cpp
+++ b/src/CaptureOptions.cpp
@@ -232,8 +232,8 @@ bool CCaptureOptions::WriteSettings(CSettings &Settings)
 	Settings.Write(TEXT("JpegQuality"), m_JPEGQuality);
 	Settings.Write(TEXT("PngCompressionLevel"), m_PNGCompressionLevel);
 	Settings.Write(TEXT("CaptureSizeType"), m_CaptureSizeType);
-	Settings.Write(TEXT("CaptureWidth"), m_SizeList[m_CaptureSize].cx);
-	Settings.Write(TEXT("CaptureHeight"), m_SizeList[m_CaptureSize].cy);
+	Settings.Write(TEXT("CaptureWidth"), static_cast<int>(m_SizeList[m_CaptureSize].cx));
+	Settings.Write(TEXT("CaptureHeight"), static_cast<int>(m_SizeList[m_CaptureSize].cy));
 	Settings.Write(TEXT("CaptureRatioNum"), m_PercentageList[m_CapturePercentage].Num);
 	Settings.Write(TEXT("CaptureRatioDenom"), m_PercentageList[m_CapturePercentage].Denom);
 	return true;

--- a/src/Graphics.cpp
+++ b/src/Graphics.cpp
@@ -435,9 +435,7 @@ bool CCanvas::FillRect(CBrush *pBrush, const RECT &Rect)
 			&& pBrush != nullptr && pBrush->m_Brush) {
 		return m_Graphics->FillRectangle(
 			pBrush->m_Brush.get(),
-			Rect.left, Rect.top,
-			Rect.right - Rect.left,
-			Rect.bottom - Rect.top) == Gdiplus::Ok;
+			GdiplusRect(Rect)) == Gdiplus::Ok;
 	}
 	return false;
 }

--- a/src/HomeDisplay.h
+++ b/src/HomeDisplay.h
@@ -89,7 +89,7 @@ namespace TVTest
 				HDC hdc, const StyleInfo & Style, const RECT & ContentRect, const RECT & PaintRect,
 				Theme::CThemeDraw & ThemeDraw) const = 0;
 			virtual bool GetCurItemRect(RECT * pRect) const = 0;
-			virtual bool SetFocus(bool fFocus) {}
+			virtual bool SetFocus(bool fFocus) = 0;
 			virtual bool IsFocused() const = 0;
 			virtual bool OnDecide() { return false; }
 			virtual void OnWindowCreate() {}

--- a/src/Layout.cpp
+++ b/src/Layout.cpp
@@ -338,7 +338,7 @@ bool CSplitter::ReplacePane(int Index, CContainer *pContainer)
 CContainer *CSplitter::GetPane(int Index) const
 {
 	if (Index < 0 || Index > 1)
-		return false;
+		return nullptr;
 	return m_PaneList[Index].pContainer;
 }
 

--- a/src/LogoManager.cpp
+++ b/src/LogoManager.cpp
@@ -646,11 +646,11 @@ CLogoManager::CLogoData *CLogoManager::LoadLogoData(WORD NetworkID, WORD LogoID,
 	TCHAR szDirectory[MAX_PATH], szFileName[MAX_PATH], szMask[32];
 
 	if (!GetAbsolutePath(m_LogoDirectory.c_str(), szDirectory, lengthof(szDirectory)))
-		return false;
+		return nullptr;
 	// 最もバージョンが新しいロゴを探す
 	StringPrintf(szMask, TEXT("%04X_%03X_\?\?\?_%02X"), NetworkID, LogoID, LogoType);
 	if (::lstrlen(szDirectory) + 1 + ::lstrlen(szMask) >= lengthof(szFileName))
-		return false;
+		return nullptr;
 	::PathCombine(szFileName, szDirectory, szMask);
 	WIN32_FIND_DATA fd;
 	HANDLE hFind = ::FindFirstFileEx(szFileName, FindExInfoBasic, &fd, FindExSearchNameMatch, nullptr, 0);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -4767,7 +4767,7 @@ void CMainWindow::HookChildWindow(HWND hwnd)
 		TRACE(TEXT("Hook window %p \"%s\"\n"), hwnd, szClass);
 #endif
 		WNDPROC pOldWndProc = SubclassWindow(hwnd, ChildHookProc);
-		::SetProp(hwnd, MAKEINTATOM(m_atomChildOldWndProcProp), pOldWndProc);
+		::SetProp(hwnd, MAKEINTATOM(m_atomChildOldWndProcProp), reinterpret_cast<HANDLE>(pOldWndProc));
 		::SetProp(hwnd, CHILD_PROP_THIS, this);
 	}
 }
@@ -4775,7 +4775,7 @@ void CMainWindow::HookChildWindow(HWND hwnd)
 
 LRESULT CALLBACK CMainWindow::ChildHookProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	WNDPROC pOldWndProc = static_cast<WNDPROC>(::GetProp(hwnd, MAKEINTATOM(m_atomChildOldWndProcProp)));
+	WNDPROC pOldWndProc = reinterpret_cast<WNDPROC>(::GetProp(hwnd, MAKEINTATOM(m_atomChildOldWndProcProp)));
 
 	if (pOldWndProc == nullptr)
 		return ::DefWindowProc(hwnd, uMsg, wParam, lParam);

--- a/src/StreamInfo.cpp
+++ b/src/StreamInfo.cpp
@@ -1124,10 +1124,10 @@ void CStreamInfo::SaveSettings(CSettings &Settings) const
 	if (IsPositionSet()) {
 		RECT rc;
 		GetPosition(&rc);
-		Settings.Write(TEXT("StreamInfoLeft"), rc.left);
-		Settings.Write(TEXT("StreamInfoTop"), rc.top);
-		Settings.Write(TEXT("StreamInfoWidth"), rc.right - rc.left);
-		Settings.Write(TEXT("StreamInfoHeight"), rc.bottom - rc.top);
+		Settings.Write(TEXT("StreamInfoLeft"), static_cast<int>(rc.left));
+		Settings.Write(TEXT("StreamInfoTop"), static_cast<int>(rc.top));
+		Settings.Write(TEXT("StreamInfoWidth"), static_cast<int>(rc.right - rc.left));
+		Settings.Write(TEXT("StreamInfoHeight"), static_cast<int>(rc.bottom - rc.top));
 	}
 
 	Settings.Write(TEXT("StreamInfo.ActivePage"), m_CurrentPage);

--- a/src/VideoDecoderOptions.h
+++ b/src/VideoDecoderOptions.h
@@ -41,7 +41,7 @@ namespace TVTest
 		bool WriteSettings(CSettings &Settings) override;
 		bool ApplyVideoDecoderSettings();
 		void SetVideoDecoderSettings(const VideoDecoderSettings &Settings) { m_VideoDecoderSettings = Settings; }
-		const VideoDecoderSettings &GetVideoDecoderSettings() const { m_VideoDecoderSettings; }
+		const VideoDecoderSettings &GetVideoDecoderSettings() const { return m_VideoDecoderSettings; }
 
 	private:
 		VideoDecoderSettings m_VideoDecoderSettings;


### PR DESCRIPTION
gccでコンパイルした過程でエラーになったものをまとめました。以下2件はMSVCでは柔軟に？扱ってくれるので迷ったのですが、一応コミットに含めます。

1. `CSettings::Write()`のオーバーロード解決について、long型はint型よりランクが高い(`sizeof(long)==4`であっても)ので整数昇格ではなく、暗黙の変換シーケンスにおいてlong->intとlong->unsigned intのどっちが最良か決まらないようです。`FillRectangle()`も同様です。

2. 関数ポインタとvoid*との間は再解釈が必要(可能かどうかは処理系依存)です ( https://en.cppreference.com/w/cpp/language/reinterpret_cast の(8))。
