### PR TITLE
CPanelFormのデストラクタで破棄済みオブジェクトへのアクセスが発生するのを修正

### DIFF
--- a/src/MainPanel.h
+++ b/src/MainPanel.h
@@ -39,12 +39,13 @@ namespace TVTest
 	{
 	public:
 		CPanelFrame Frame;
-		CPanelForm Form;
 		CInformationPanel InfoPanel;
 		CProgramListPanel ProgramListPanel;
 		CChannelPanel ChannelPanel;
 		CCaptionPanel CaptionPanel;
 		CControlPanel ControlPanel;
+		// CPanelFormのデストラクタからパネル項目に通知が送られるので、宣言の順序に注意
+		CPanelForm Form;
 		bool fShowPanelWindow;
 
 		CMainPanel();


### PR DESCRIPTION
CPanelFormのデストラクタで`InfoPanel`～`ControlPanel`パネル項目の`OnFormDelete()`が呼ばれますが、宣言順の関係でこれらのパネル項目はすでに破棄済みです。
各項目の`OnFormDelete()`は何もしないので、厳密には破棄済みオブジェクトのvtableポインタ隠しメンバへの不正なアクセスです。

// 別案でCPluginPanelItemみたいに動的確保で統一すると、オブジェクトの階層的にはすこし綺麗な感じもします（長短あり）