### PR TITLE
Visual Studioのバージョンチェックをルーズ化

### DIFF
--- a/sdk/Samples/Samples.sln
+++ b/sdk/Samples/Samples.sln
@@ -2,7 +2,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.32428.217
-MinimumVisualStudioVersion = 16.0.32428.217
+MinimumVisualStudioVersion = 16.0.28729.10
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "AutoSnapShot", "AutoSnapShot\AutoSnapShot.vcxproj", "{178CA9B3-D4E4-46AC-89F1-96E163B2E369}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PacketCounter", "PacketCounter\PacketCounter.vcxproj", "{BCDA86B2-7DE3-4F8F-B54B-91EFD4154E36}"

--- a/src/TVTest.sln
+++ b/src/TVTest.sln
@@ -2,7 +2,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.32428.217
-MinimumVisualStudioVersion = 16.0.32428.217
+MinimumVisualStudioVersion = 16.0.28729.10
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TVTest", "TVTest.vcxproj", "{88CAD0EE-D7F6-412D-8691-D1FF19534587}"
 	ProjectSection(ProjectDependencies) = postProject
 		{77F6A763-E1AD-4A5F-BFD1-A99756FE412C} = {77F6A763-E1AD-4A5F-BFD1-A99756FE412C}


### PR DESCRIPTION
Windows 7には適用できないバージョンがミニマムバージョンだったため