### PR TITLE
ログファイル逐次書き込みを改善

### DIFF
--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -104,10 +104,16 @@ int CLogItem::FormatTime(char *pszText, int MaxLength) const
 	Length = ::GetDateFormatA(
 		LOCALE_USER_DEFAULT, DATE_SHORTDATE,
 		&st, nullptr, pszText, MaxLength - 1);
+	if (Length < 1)
+		Length = 1;
 	pszText[Length - 1] = ' ';
-	Length += ::GetTimeFormatA(
+	int TimeLength = ::GetTimeFormatA(
 		LOCALE_USER_DEFAULT, TIME_FORCE24HOURFORMAT,
 		&st, nullptr, pszText + Length, MaxLength - Length);
+	if (TimeLength < 1)
+		TimeLength = 1;
+	Length += TimeLength;
+	pszText[Length - 1] = '\0';
 	return Length - 1;
 }
 
@@ -121,10 +127,16 @@ int CLogItem::FormatTime(WCHAR *pszText, int MaxLength) const
 	Length = ::GetDateFormatW(
 		LOCALE_USER_DEFAULT, DATE_SHORTDATE,
 		&st, nullptr, pszText, MaxLength - 1);
+	if (Length < 1)
+		Length = 1;
 	pszText[Length - 1] = L' ';
-	Length += ::GetTimeFormatW(
+	int TimeLength = ::GetTimeFormatW(
 		LOCALE_USER_DEFAULT, TIME_FORCE24HOURFORMAT,
 		&st, nullptr, pszText + Length, MaxLength - Length);
+	if (TimeLength < 1)
+		TimeLength = 1;
+	Length += TimeLength;
+	pszText[Length - 1] = L'\0';
 	return Length - 1;
 }
 

--- a/src/Logger.h
+++ b/src/Logger.h
@@ -102,11 +102,15 @@ namespace TVTest
 	// CUIBase
 		void RealizeStyle() override;
 
+	// CLogger
+		bool CreateFileLock(CGlobalLock *pLock) const;
+
 		std::vector<std::unique_ptr<CLogItem>> m_LogList;
 		DWORD m_SerialNumber;
 		bool m_fOutputToFile;
 		mutable MutexLock m_Lock;
 		String m_DefaultLogFileName;
+		HANDLE m_hFile;
 	};
 
 }	// namespace TVTest


### PR DESCRIPTION
現状の逐次書き込み機能はログファイルを排他書き込みモードで開くため、複数プロセス起動中に競合する `CreateFile()` がたまに失敗してログが欠落します。
TVTestのログは通常1秒に何十回も追記される性質のものではないので、"ファイルを開いたまま書き込みだけロックする" については希望であれば逐次ひらく方式に戻します (プロセス起動中にログファイルを移動したり削除したい場合など)。