### PR TITLE
StringFormat 書式文字列内の括弧を修正

### DIFF
--- a/src/AppMain.cpp
+++ b/src/AppMain.cpp
@@ -1335,7 +1335,7 @@ CAppMain::CreateDirectoryResult CAppMain::CreateDirectory(
 		if (Result != ERROR_SUCCESS && Result != ERROR_ALREADY_EXISTS) {
 			StringFormat(
 				szMessage,
-				TEXT("フォルダ \"{}\" を作成できません。(エラーコード {{:#x})"), szPath, Result);
+				TEXT("フォルダ \"{}\" を作成できません。(エラーコード {:#x})"), szPath, Result);
 			AddLog(CLogItem::LogType::Error, szMessage);
 			::MessageBox(hwnd, szMessage, nullptr, MB_OK | MB_ICONEXCLAMATION);
 			return CreateDirectoryResult::Error;


### PR DESCRIPTION
- `StringFormat` の書式文字列内に不正な中括弧があったため、ビルドに失敗していたのを修正しました
  - 発生したコンパイルエラー
  ```
  src\AppMain.cpp(1338,5): error C7595: 'std::basic_format_string<wchar_t,TCHAR (&)[260],const int &>::basic_format_string':
  call to immediate function is not a constant expression [src\TVTest.vcxproj]
  ```

- 確認した環境
  - Visual Studio Enterprise 2022 17.7.34202.233
  - MSBuild 17.7.2+d6990bcfa
  - PlatformToolset=v143
  - Release_MD x64
