### PR TITLE
Fix potential vulnerability in cloned code

### DIFF
--- a/src/TVTest_Image/libjpeg/rdtarga.c
+++ b/src/TVTest_Image/libjpeg/rdtarga.c
@@ -365,7 +365,8 @@ start_input_tga (j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
       width <= 0 || height <= 0 ||
       source->pixel_size < 1 || source->pixel_size > 4 ||
       (UCH(targaheader[16]) & 7) != 0 || /* bits/pixel must be multiple of 8 */
-      interlace_type != 0)	/* currently don't allow interlaced image */
+      interlace_type != 0 ||      /* currently don't allow interlaced image */
+      width == 0 || height == 0)  /* image width/height must be non-zero */
     ERREXIT(cinfo, JERR_TGA_BADPARMS);
 
   if (subtype > 8) {


### PR DESCRIPTION
This PR fixes a potential security vulnerability in `start_input_tga` that was cloned from `libjpeg-turbo/libjpeg-turbo` but did not receive the security patch.

**Vulnerability Details:**

* **Affected Function**: `start_input_tga` in `libs/SDL2_jpeg/src/rdtarga.c`
* **Original Fix**: https://github.com/libjpeg-turbo/libjpeg-turbo/commit/82923eb93a2eacf4a593e00e3e672bbb86a8a3a0

**What this PR does:** This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

**References:**

* https://github.com/libjpeg-turbo/libjpeg-turbo/commit/82923eb93a2eacf4a593e00e3e672bbb86a8a3a0

Please review and merge this PR to ensure your repository is protected against this vulnerability.